### PR TITLE
Add checkm8, improve formatting and remove item

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ A list of lists involving IoT security in general 🇧🇷 🇺🇸
     - Android Security Bulletin (2015-2020)
       https://source.android.com/security/bulletin
       
+    - checkm8: an unpatchable bootrom exploit for hundreds of millions of iOS devices (2019)
+      https://twitter.com/axi0mX/status/1177542201670168576
+      
     - Opening Pandora’s Box through ATFuzzer: Dynamic Analysis of AT Interface for Android Smartphones (2019)
       https://github.com/Imtiazkarimik23/ATFuzzer
       

--- a/README.md
+++ b/README.md
@@ -71,9 +71,6 @@ A list of lists involving IoT security in general 🇧🇷 🇺🇸
 	- ATtention Spanned: Comprehensive Vulnerability Analysis ofAT Commands Within the Android Ecosystem (2018)
       https://www.usenix.org/system/files/conference/usenixsecurity18/sec18-tian.pdf
       
-	- Exploiting Android Devices Running Insecure Remote ADB Service (2018)
-      https://blog.usejournal.com/exploiting-android-devices-running-insecure-remote-adb-service-4490cc6a2282
-      
 	- MTPwn (2017)
       https://github.com/smeso/MTPwn
       

--- a/README.md
+++ b/README.md
@@ -55,49 +55,49 @@ A list of lists involving IoT security in general 🇧🇷 🇺🇸
     
 7. Mobile Devices USB known vulns
     
-    - Android Security Bulletin (2015-2020)
+    - Android Security Bulletin (2015-2020)  
       https://source.android.com/security/bulletin
       
-    - checkm8: an unpatchable bootrom exploit for hundreds of millions of iOS devices (2019)
+    - checkm8: an unpatchable bootrom exploit for hundreds of millions of iOS devices (2019)  
       https://twitter.com/axi0mX/status/1177542201670168576
       
-    - Opening Pandora’s Box through ATFuzzer: Dynamic Analysis of AT Interface for Android Smartphones (2019)
+    - Opening Pandora’s Box through ATFuzzer: Dynamic Analysis of AT Interface for Android Smartphones (2019)  
       https://github.com/Imtiazkarimik23/ATFuzzer
       
-    - Android: directory traversal over USB via injection in blkid output (2018)
-      https://www.exploit-db.com/exploits/45192
+    - Android: directory traversal over USB via injection in blkid output (2018)  
+      https://www.exploit-db.com/exploits/45192  
       https://bugs.chromium.org/p/project-zero/issues/detail?id=1583
       
-	- OATmeal on the Universal Cereal Bus: Exploiting Android phones over USB (2018)
+	- OATmeal on the Universal Cereal Bus: Exploiting Android phones over USB (2018)  
       https://googleprojectzero.blogspot.com/2018/09/oatmeal-on-universal-cereal-bus.html
       
-	- ATtention Spanned: Comprehensive Vulnerability Analysis ofAT Commands Within the Android Ecosystem (2018)
+	- ATtention Spanned: Comprehensive Vulnerability Analysis ofAT Commands Within the Android Ecosystem (2018)  
       https://www.usenix.org/system/files/conference/usenixsecurity18/sec18-tian.pdf
       
-	- MTPwn (2017)
+	- MTPwn (2017)  
       https://github.com/smeso/MTPwn
       
-	- Exploring USB Connection Vulnerabilities on Android Devices: Breaches using the Android Debug Bridge (2017)
+	- Exploring USB Connection Vulnerabilities on Android Devices: Breaches using the Android Debug Bridge (2017)  
       https://www.scitepress.org/Papers/2017/64759/64759.pdf
       
-	- Google Nexus 6 f_usbnet Kernel Uninitialized Memory Leak Over USB (2016)
+	- Google Nexus 6 f_usbnet Kernel Uninitialized Memory Leak Over USB (2016)  
       https://exchange.xforce.ibmcloud.com/collection/Google-Nexus-6-f_usbnet-Kernel-Uninitialized-Memory-Leak-Over-USB-c123bbfb8ef3c70a0cd4c0172d54b0d0
       
-	- Attacking Nexus 6 & 6P Custom Bootmodes (2016)
+	- Attacking Nexus 6 & 6P Custom Bootmodes (2016)  
       https://exchange.xforce.ibmcloud.com/collection/Attacking-Nexus-6-and-6P-Custom-Bootmodes-5985d26456a31dd4d21a7d6ee065bb1b
       
-	- DualToy: New Windows Trojan Sideloads Risky Apps to Android and iOS Devices (2016)
+	- DualToy: New Windows Trojan Sideloads Risky Apps to Android and iOS Devices (2016)  
       https://unit42.paloaltonetworks.com/dualtoy-new-windows-trojan-sideloads-risky-apps-to-android-and-ios-devices/
       
-	- USB connection vulnerabilities on Android smartphones: default and vendors’ customizations (2014)
-      https://www.researchgate.net/profile/Manuel_Eduardo_Correia/publication/264003931_USB_Connection_Vulnerabilities_on_Android_Smartphones_Default_and_Vendors'_Customizations/links/544f6e8e0cf29473161c3a15/USB-Connection-Vulnerabilities-on-Android-Smartphones-Default-and-Vendors-Customizations.pdf
+	- USB connection vulnerabilities on Android smartphones: default and vendors’ customizations (2014)  
+	https://www.researchgate.net/profile/Manuel_Eduardo_Correia/publication/264003931_USB_Connection_Vulnerabilities_on_Android_Smartphones_Default_and_Vendors'_Customizations/links/544f6e8e0cf29473161c3a15/USB-Connection-Vulnerabilities-on-Android-Smartphones-Default-and-Vendors-Customizations.pdf
       https://repositorio-aberto.up.pt/bitstream/10216/76109/2/32399.pdf
       
-	- Android 4.4.2 Secure USB Debugging Bypass (2014)
+	- Android 4.4.2 Secure USB Debugging Bypass (2014)  
       https://labs.f-secure.com/advisories/android-4-4-2-secure-usb-debugging-bypass/
       
-	- Mactans Injecting Malware into iOS Devices via Malicious Chargers (2013)
+	- Mactans Injecting Malware into iOS Devices via Malicious Chargers (2013)  
       https://media.blackhat.com/us-13/US-13-Lau-Mactans-Injecting-Malware-into-iOS-Devices-via-Malicious-Chargers-WP.pdf
       
-	- Exploiting Smart-Phone USB Connectivity For Fun And Profit (2011)
+	- Exploiting Smart-Phone USB Connectivity For Fun And Profit (2011)  
       https://media.blackhat.com/bh-dc-11/Stavrou-Wang/BlackHat_DC_2011_Stavrou_Zhaohui_USB_exploits-Slides.pdf


### PR DESCRIPTION
This pull request includes the following changes:

- Adds [checkm8](https://twitter.com/axi0mX/status/1177542201670168576) to the list of USB vulnerabilities affecting mobile devices;
- Adds a newline between the titles and URLs of each item (improved formatting);
- Removes _“[Exploiting Android Devices Running Insecure Remote ADB Service (2018)](https://blog.usejournal.com/exploiting-android-devices-running-insecure-remote-adb-service-4490cc6a2282)”_ because the article refers to exploitation of ADB services exposed to a network, not over USB;